### PR TITLE
Added beforeAddFile() action hook

### DIFF
--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -19,6 +19,7 @@ export class NgFileDropDirective {
   @Output() onFileOver:EventEmitter<any> = new EventEmitter();
   @Output() onUploadRejected: EventEmitter<UploadRejected> = new EventEmitter<UploadRejected>();
   @Output() beforeUpload: EventEmitter<UploadedFile> = new EventEmitter<UploadedFile>();
+  @Output() beforeAddFile: EventEmitter<UploadedFile> = new EventEmitter<UploadedFile>();
 
    _options:any;
 
@@ -54,6 +55,10 @@ export class NgFileDropDirective {
 
     this.uploader._beforeEmitter.subscribe((uploadingFile: UploadedFile) => {
       this.beforeUpload.emit(uploadingFile)
+    });
+
+    this.uploader._beforeAddFileEmitter.subscribe((uploadingFile: UploadedFile) => {
+      this.beforeAddFile.emit(uploadingFile)
     });
 
     setTimeout(() => {

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -18,6 +18,7 @@ export class NgFileSelectDirective {
   @Output() onPreviewData: EventEmitter<any> = new EventEmitter();
   @Output() onUploadRejected: EventEmitter<UploadRejected> = new EventEmitter<UploadRejected>();
   @Output() beforeUpload: EventEmitter<UploadedFile> = new EventEmitter<UploadedFile>();
+  @Output() beforeAddFile: EventEmitter<UploadedFile> = new EventEmitter<UploadedFile>();
 
   _options: any;
 
@@ -56,6 +57,10 @@ export class NgFileSelectDirective {
 
     this.uploader._beforeEmitter.subscribe((uploadingFile: UploadedFile) => {
       this.beforeUpload.emit(uploadingFile)
+    });
+
+    this.uploader._beforeAddFileEmitter.subscribe((uploadingFile: UploadedFile) => {
+      this.beforeAddFile.emit(uploadingFile)
     });
 
     setTimeout(() => {

--- a/src/services/ng2-uploader.ts
+++ b/src/services/ng2-uploader.ts
@@ -85,6 +85,7 @@ export class Ng2Uploader {
   _emitter: EventEmitter<any> = new EventEmitter();
   _previewEmitter: EventEmitter<any> = new EventEmitter();
   _beforeEmitter: EventEmitter<any> = new EventEmitter();
+  _beforeAddFileEmitter: EventEmitter<any> = new EventEmitter();
 
   setOptions(options: any): void {
     this.url = options.url != null ? options.url : this.url;
@@ -224,6 +225,8 @@ export class Ng2Uploader {
     if (this.previewUrl) {
       files.forEach(file => this.createFileUrl(file));
     }
+
+    files.forEach(file => this._beforeAddFileEmitter.emit(file));
 
     if (this.autoUpload) {
       this.uploadFilesInQueue();


### PR DESCRIPTION
This PR makes call **beforeAddFile** action hook.
It is especially useful when triggering file upload manually (with the press of upload button and `autoUpload: false` option turned off), because **beforeUpload** action hook is fired only when **uploadFile()** is  called. Thus you can get the details of file or files to be uploaded, to show the presubmit view.

**How to use:**
Add `(beforeAddFile)="beforeAddFileFn($event)"` in html, and in ts:

```ts
beforeAddFileFn(file) {
   // file details
}
```