### PR TITLE
Fixed issue with filter of undefined when using an <input type="file">

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "ngx-uploader",
-  "description": "Angular File Uploader",
-  "version": "2.0.3",
-  "license": "MIT",
-  "main": "index.js",
-  "typings": "index.d.ts",
-  "author": "Jan Kuri <jkuri88@gmail.com>",
-  "scripts": {
-    "clean": "./scripts/clean.sh",
-    "dev": "tsc --watch",
-    "build": "./node_modules/.bin/ngc -p tsconfig.json",
-    "prepublish": "npm run build",
-    "docs": "gulp docs",
-    "changelog": "gulp changelog"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/jkuri/ngx-uploader.git"
-  },
-  "keywords": [
-    "ngx",
-    "angular",
-    "file",
-    "upload",
-    "uploader"
-  ],
-  "devDependencies": {
-    "@angular/common": "^2.4.1",
-    "@angular/compiler": "^2.4.1",
-    "@angular/compiler-cli": "^2.4.1",
-    "@angular/core": "^2.4.1",
-    "@angular/platform-browser": "^2.4.1",
-    "@angular/platform-browser-dynamic": "^2.4.1",
-    "@angular/platform-server": "^2.4.1",
-    "@types/core-js": "^0.9.35",
-    "@types/node": "^6.0.52",
-    "gulp": "^3.9.1",
-    "gulp-conventional-changelog": "^1.1.0",
-    "gulp-typedoc": "^2.0.1",
-    "reflect-metadata": "^0.1.9",
-    "rxjs": "5.0.1",
-    "typedoc": "^0.5.1",
-    "typescript": "2.0.10",
-    "zone.js": "^0.7.4"
-  }
+    "name": "ngx-uploader",
+    "description": "Angular File Uploader",
+    "version": "2.0.4",
+    "license": "MIT",
+    "main": "index.js",
+    "typings": "index.d.ts",
+    "author": "Jan Kuri <jkuri88@gmail.com>",
+    "scripts": {
+        "clean": "./scripts/clean.sh",
+        "dev": "tsc --watch",
+        "build": "./node_modules/.bin/ngc -p tsconfig.json",
+        "prepublish": "npm run build",
+        "docs": "gulp docs",
+        "changelog": "gulp changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/jkuri/ngx-uploader.git"
+    },
+    "keywords": [
+        "ngx",
+        "angular",
+        "file",
+        "upload",
+        "uploader"
+    ],
+    "devDependencies": {
+        "@angular/common": "^2.4.1",
+        "@angular/compiler": "^2.4.1",
+        "@angular/compiler-cli": "^2.4.1",
+        "@angular/core": "^2.4.1",
+        "@angular/platform-browser": "^2.4.1",
+        "@angular/platform-browser-dynamic": "^2.4.1",
+        "@angular/platform-server": "^2.4.1",
+        "@types/core-js": "^0.9.35",
+        "@types/node": "^6.0.52",
+        "gulp": "^3.9.1",
+        "gulp-conventional-changelog": "^1.1.0",
+        "gulp-typedoc": "^2.0.1",
+        "reflect-metadata": "^0.1.9",
+        "rxjs": "5.0.1",
+        "typedoc": "^0.5.1",
+        "typescript": "2.0.10",
+        "zone.js": "^0.7.4"
+    }
 }

--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -35,7 +35,7 @@ export class NgFileDropDirective implements OnChanges, OnInit {
     this.uploader._emitter.subscribe((data: any) => {
       this.onUpload.emit(data);
       if (data.done && this.files && this.files.length) {
-        this.files = Array.prototype.filter.call(this.files, (x: any) => x.name !== data.originalName)
+        this.files = [].filter.call(this.files, (x: any) => x.name !== data.originalName)
       }
     });
 

--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -35,7 +35,7 @@ export class NgFileDropDirective implements OnChanges, OnInit {
     this.uploader._emitter.subscribe((data: any) => {
       this.onUpload.emit(data);
       if (data.done && this.files && this.files.length) {
-        this.files = this.files.filter(f => f.name !== data.originalName);
+        this.files = Array.prototype.filter.call(this.files, (x: any) => x.name !== data.originalName)
       }
     });
 

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -39,7 +39,7 @@ export class NgFileSelectDirective implements OnChanges {
     this.uploader._emitter.subscribe((data: any) => {
       this.onUpload.emit(data);
       if (data.done && this.files && this.files.length) {
-        this.files = Array.prototype.filter.call(this.files, (x: any) => x.name !== data.originalName)
+        this.files = [].filter.call(this.files, (x: any) => x.name !== data.originalName)
       }
     });
 

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -39,7 +39,7 @@ export class NgFileSelectDirective implements OnChanges {
     this.uploader._emitter.subscribe((data: any) => {
       this.onUpload.emit(data);
       if (data.done && this.files && this.files.length) {
-        this.files = this.files.filter(f => f.name !== data.originalName);
+        this.files = Array.prototype.filter.call(this.files, (x: any) => x.name !== data.originalName)
       }
     });
 


### PR DESCRIPTION
As it returns a FileList instead of an array, instead i made use of the prototype.filter.call, which works perfectly in this situation where you use both the dropzone and the file input type :) 

fixes #164 