### PR TITLE
Support for „strictNullChecks” in tsconfig 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /typings
 
 !gulpfile.js
+/.idea

--- a/src/classes/ng-uploader-options.class.ts
+++ b/src/classes/ng-uploader-options.class.ts
@@ -1,3 +1,5 @@
+export type Method = 'POST'|'GET';
+
 export interface INgUploaderOptions {
   url: string;
   cors?: boolean;
@@ -7,7 +9,7 @@ export interface INgUploaderOptions {
   data?: any;
   autoUpload?: boolean;
   multipart?: any;
-  method?: 'POST' | 'GET';
+  method?: Method;
   customHeaders?: any;
   encodeHeaders?: boolean;
   authTokenPrefix?: string;
@@ -29,7 +31,7 @@ export class NgUploaderOptions implements INgUploaderOptions {
   data?: any;
   autoUpload: boolean;
   multipart?: any;
-  method: 'POST' | 'GET';
+  method: Method;
   customHeaders: any;
   encodeHeaders: boolean;
   authTokenPrefix: string;
@@ -42,24 +44,29 @@ export class NgUploaderOptions implements INgUploaderOptions {
   allowedExtensions: string[];
 
   constructor(obj: INgUploaderOptions) {
-    this.url = obj && obj.url ? obj.url : '';
-    this.cors = obj && obj.cors ? obj.cors : true;
-    this.withCredentials = obj && obj.withCredentials ? obj.withCredentials : this.withCredentials;
-    this.multiple = obj && obj.multiple ? obj.multiple : true;
-    this.maxUploads = obj && obj.maxUploads ? obj.maxUploads : 10;
-    this.data = obj && obj.data ? obj.data : {};
-    this.autoUpload = obj && obj.autoUpload ? obj.autoUpload : true;
-    this.multipart = obj && obj.multipart ? obj.multipart : false;
-    this.method = obj && obj.method ? obj.method : 'POST';
-    this.customHeaders = obj && obj.customHeaders ? obj.customHeaders : {};
-    this.encodeHeaders = obj && obj.encodeHeaders ? obj.encodeHeaders : false;
-    this.authTokenPrefix = obj && obj.authTokenPrefix ? obj.authTokenPrefix : 'Bearer';
-    this.authToken = obj && obj.authToken ? obj.authToken : undefined;
-    this.fieldName = obj && obj.fieldName ? obj.fieldName : 'file';
-    this.fieldReset = obj && obj.fieldReset ? obj.fieldReset : false;
-    this.previewUrl = obj && obj.previewUrl ? obj.previewUrl : undefined;
-    this.calculateSpeed = obj && obj.calculateSpeed ? obj.calculateSpeed : true;
-    this.filterExtensions = obj && obj.filterExtensions ? obj.filterExtensions : false;
-    this.allowedExtensions = obj && obj.allowedExtensions ? obj.allowedExtensions : [];
+    function use<T>(source: T|undefined, defaultValue: T): T {
+      return obj && source !== undefined ? source : defaultValue;
+    }
+
+    this.url = use(obj.url, '');
+    this.cors = use(obj.cors, true);
+    this.withCredentials = use(obj.withCredentials, this.withCredentials);
+    this.multiple = use(obj.multiple, true);
+    this.maxUploads = use(obj.maxUploads, 10);
+    this.data = use(obj.data, {});
+    this.autoUpload = use(obj.autoUpload, true);
+    this.multipart = use(obj.multipart, false);
+    this.method = use(obj.method, <Method>'POST');
+    this.customHeaders = use(obj.customHeaders, {});
+    this.encodeHeaders = use(obj.encodeHeaders, false);
+    this.authTokenPrefix = use(obj.authTokenPrefix, 'Bearer');
+    this.authToken = use(obj.authToken, undefined);
+    this.fieldName = use(obj.fieldName, 'file');
+    this.fieldReset = use(obj.fieldReset, false);
+    this.previewUrl = use(obj.previewUrl, undefined);
+    this.calculateSpeed = use(obj.calculateSpeed, true);
+    this.filterExtensions = use(obj.filterExtensions, false);
+    this.allowedExtensions = use(obj.allowedExtensions, []);
   }
+
 }

--- a/src/classes/ng-uploader-options.class.ts
+++ b/src/classes/ng-uploader-options.class.ts
@@ -48,9 +48,9 @@ export class NgUploaderOptions implements INgUploaderOptions {
       return obj && source !== undefined ? source : defaultValue;
     }
 
-    this.url = use(obj.url, '');
+    this.url = use(obj.url, <string>'');
     this.cors = use(obj.cors, true);
-    this.withCredentials = use(obj.withCredentials, this.withCredentials);
+    this.withCredentials = use(obj.withCredentials, false);
     this.multiple = use(obj.multiple, true);
     this.maxUploads = use(obj.maxUploads, 10);
     this.data = use(obj.data, {});

--- a/src/classes/ng-uploader-options.class.ts
+++ b/src/classes/ng-uploader-options.class.ts
@@ -22,44 +22,44 @@ export interface INgUploaderOptions {
 
 export class NgUploaderOptions implements INgUploaderOptions {
   url: string;
-  cors?: boolean;
-  withCredentials?: boolean;
-  multiple?: boolean;
+  cors: boolean;
+  withCredentials: boolean;
+  multiple: boolean;
   maxUploads?: number;
   data?: any;
-  autoUpload?: boolean;
+  autoUpload: boolean;
   multipart?: any;
-  method?: 'POST' | 'GET';
-  customHeaders?: any;
-  encodeHeaders?: boolean;
-  authTokenPrefix?: string;
+  method: 'POST' | 'GET';
+  customHeaders: any;
+  encodeHeaders: boolean;
+  authTokenPrefix: string;
   authToken?: string;
-  fieldName?: string;
-  fieldReset?: boolean;
+  fieldName: string;
+  fieldReset: boolean;
   previewUrl?: string;
-  calculateSpeed?: boolean;
-  filterExtensions?: boolean;
-  allowedExtensions?: string[];
+  calculateSpeed: boolean;
+  filterExtensions: boolean;
+  allowedExtensions: string[];
 
   constructor(obj: INgUploaderOptions) {
-    this.url = obj.url != null ? obj.url : '';
-    this.cors = obj.cors != null ? obj.cors : true;
-    this.withCredentials = obj.withCredentials != null ? obj.withCredentials : this.withCredentials;
-    this.multiple = obj.multiple != null ? obj.multiple : true;
-    this.maxUploads = obj.maxUploads != null ? obj.maxUploads : 10;
-    this.data = obj.data != null ? obj.data : {};
+    this.url = obj && obj.url ? obj.url : '';
+    this.cors = obj && obj.cors ? obj.cors : true;
+    this.withCredentials = obj && obj.withCredentials ? obj.withCredentials : this.withCredentials;
+    this.multiple = obj && obj.multiple ? obj.multiple : true;
+    this.maxUploads = obj && obj.maxUploads ? obj.maxUploads : 10;
+    this.data = obj && obj.data ? obj.data : {};
     this.autoUpload = obj && obj.autoUpload ? obj.autoUpload : true;
-    this.multipart = obj.multipart != null ? obj.multipart : false;
-    this.method = obj.method != null ? obj.method : 'POST';
-    this.customHeaders = obj.customHeaders != null ? obj.customHeaders : { };
-    this.encodeHeaders = obj.encodeHeaders != null ? obj.encodeHeaders : false;
-    this.authTokenPrefix = obj.authTokenPrefix != null ? obj.authTokenPrefix : 'Bearer';
-    this.authToken = obj.authToken != null ? obj.authToken : null;
-    this.fieldName = obj.fieldName != null ? obj.fieldName : 'file';
-    this.fieldReset = obj.fieldReset != null ? obj.fieldReset : null;
-    this.previewUrl = obj.previewUrl != null ? obj.previewUrl : null;
-    this.calculateSpeed = obj.calculateSpeed != null ? obj.calculateSpeed : true;
-    this.filterExtensions = obj.filterExtensions != null ? obj.filterExtensions : false;
+    this.multipart = obj && obj.multipart ? obj.multipart : false;
+    this.method = obj && obj.method ? obj.method : 'POST';
+    this.customHeaders = obj && obj.customHeaders ? obj.customHeaders : {};
+    this.encodeHeaders = obj && obj.encodeHeaders ? obj.encodeHeaders : false;
+    this.authTokenPrefix = obj && obj.authTokenPrefix ? obj.authTokenPrefix : 'Bearer';
+    this.authToken = obj && obj.authToken ? obj.authToken : undefined;
+    this.fieldName = obj && obj.fieldName ? obj.fieldName : 'file';
+    this.fieldReset = obj && obj.fieldReset ? obj.fieldReset : false;
+    this.previewUrl = obj && obj.previewUrl ? obj.previewUrl : undefined;
+    this.calculateSpeed = obj && obj.calculateSpeed ? obj.calculateSpeed : true;
+    this.filterExtensions = obj && obj.filterExtensions ? obj.filterExtensions : false;
     this.allowedExtensions = obj && obj.allowedExtensions ? obj.allowedExtensions : [];
   }
 }

--- a/src/classes/uploaded-file.class.ts
+++ b/src/classes/uploaded-file.class.ts
@@ -12,7 +12,7 @@ export class UploadedFile {
   startTime: number;
   endTime: number;
   speedAverage: number;
-  speedAverageHumanized: string;
+  speedAverageHumanized: string|null;
 
   constructor(id: string, originalName: string, size: number) {
     this.id = id;

--- a/src/services/ngx-uploader.ts
+++ b/src/services/ngx-uploader.ts
@@ -49,7 +49,7 @@ export class NgUploaderService {
     let time: number = new Date().getTime();
     let load = 0;
     let speed = 0;
-    let speedHumanized: string = null;
+    let speedHumanized: string|null = null;
 
     xhr.upload.onprogress = (e: ProgressEvent) => {
       if (e.lengthComputable) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noEmitHelpers": false,
     "noImplicitAny": true,
     "declaration": true,
+    "strictNullChecks": true,
     "skipLibCheck": true,
     "stripInternal": true,
     "lib": ["es6", "dom"],


### PR DESCRIPTION
For issue https://github.com/jkuri/ngx-uploader/issues/169:
* Added flag in `tsconfig`
* Modified `ng-uploader-options` to use null-strict values: variables that have defaults must always be defined, variables without defaults are allowed to be undefined (but not null)
* Modified `ng-uploader-options` to always check for obj presence
* Marked `speedHumanized` and `speedAverageHumanized` as nullable