### PR TITLE
Cleanup unused imports

### DIFF
--- a/src/directives/ng-file-drop.ts
+++ b/src/directives/ng-file-drop.ts
@@ -11,7 +11,7 @@ import {
   SimpleChange
 } from '@angular/core';
 import { NgUploaderService } from '../services/ngx-uploader';
-import { INgUploaderOptions, NgUploaderOptions, UploadedFile, UploadRejected } from '../classes';
+import { NgUploaderOptions, UploadedFile, UploadRejected } from '../classes';
 
 @Directive({
   selector: '[ngFileDrop]'

--- a/src/directives/ng-file-select.ts
+++ b/src/directives/ng-file-select.ts
@@ -10,7 +10,7 @@ import {
   SimpleChange
 } from '@angular/core';
 import { NgUploaderService } from '../services/ngx-uploader';
-import { INgUploaderOptions, NgUploaderOptions, UploadedFile, UploadRejected } from '../classes';
+import { NgUploaderOptions, UploadedFile, UploadRejected } from '../classes';
 
 @Directive({
   selector: '[ngFileSelect]'

--- a/src/services/ngx-uploader.ts
+++ b/src/services/ngx-uploader.ts
@@ -1,7 +1,6 @@
-import { EventEmitter, Injectable, OnChanges, Provider } from '@angular/core';
+import { EventEmitter, Injectable, Provider } from '@angular/core';
 import { NgUploaderOptions } from '../classes/ng-uploader-options.class';
 import { UploadedFile } from '../classes/uploaded-file.class';
-import { UploadRejected } from '../classes/upload-rejected.class';
 
 @Injectable()
 export class NgUploaderService {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "sourceMap": false,
     "noEmitHelpers": false,
     "noImplicitAny": true,
+    "noUnusedLocals": true,
     "declaration": true,
     "strictNullChecks": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Hi,

We are using ``"noUnusedLocals": true,`` compiler option is our project and TSC complains about some unused imports in ``ngx-uploader``. It would be great if they could be removed.

If there is a better way to suppress them, then sorry for the trouble.