### PR TITLE
ionic 2 warning fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gulp-conventional-changelog": "^1.1.0",
     "gulp-typedoc": "^2.0.1",
     "reflect-metadata": "^0.1.9",
-    "rxjs": "5.0.3",
+    "rxjs": "^5.0.3",
     "typedoc": "^0.5.3",
     "typescript": "2.1.4",
     "zone.js": "^0.7.4"


### PR DESCRIPTION
Getting warning because of `ngx-uploader`
```
├── ngx-uploader@2.0.24
├─┬ UNMET PEER DEPENDENCY rxjs@5.0.3
...
```