### PR TITLE
Fix cancelAll and cancel errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-uploader",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "main": "bundles/ngx-uploader.umd.js",
   "module": "index.js",
   "esnext": "index.js",


### PR DESCRIPTION
In this PR I switched the the way the files are added to the FormData object. I simply cast the nativeFile to Blob for upload. 
> A File object is a specific kind of a Blob, and can be used in any context that a Blob can. In particular, FileReader, URL.createObjectURL(), createImageBitmap(), and XMLHttpRequest.send() accept both Blobs and Files. 
[(https://developer.mozilla.org/en-US/docs/Web/API/File)]

That way we're not tracking by index in the FileList object which can be thrown off and produce errors as I've encountered.

Also fixed an error in which the `cancel` and `cancelAll` events were trying to unsubscribe to a subscription that isn't provided. The `sub` property is non set in the `uploadAll` event is not set. However, the initial state is `Subscription` type so the check was evaluating to true on cancel events. I changed it to `undefined` initial state. Temporary fix, should probably be adding the subscription to the `sub` property in the `uploadAll` event though so that it can be unsubscribed from.